### PR TITLE
refactor(Orchestration): Remove Initialize methods and update Orchestrate function signature

### DIFF
--- a/src/StartupOrchestration.NET/StartupOrchestrator.cs
+++ b/src/StartupOrchestration.NET/StartupOrchestrator.cs
@@ -47,10 +47,8 @@
         {
             IConfigurationRoot configuration = SetupConfiguration();
             var orchestrator = new TOrchestrator();
-            orchestrator.InitializeConfiguration(configuration);
-            orchestrator.InitializeServiceCollection(serviceCollection);
             orchestrator.ServiceRegistrationExpressions.AddRange(ServiceRegistrationExpressions);
-            orchestrator.Orchestrate();
+            orchestrator.Orchestrate(serviceCollection, configuration);
         }
 
         /// <summary>


### PR DESCRIPTION
The InitializeConfiguration and InitializeServiceCollection methods were removed as they were no longer necessary after previous refactorings. The Orchestrate function signature was updated to accept both the IServiceCollection and IConfiguration objects as parameters, removing the need for these initialize methods.