### PR TITLE
feat(logging): Enhance service registration logging with detailed method and parameter handling

### DIFF
--- a/src/StartupOrchestration.NET/ServiceRegistrationOrchestrator.cs
+++ b/src/StartupOrchestration.NET/ServiceRegistrationOrchestrator.cs
@@ -41,7 +41,7 @@
 
             foreach (Expression<Action<IServiceCollection, IConfiguration>> expression in ServiceRegistrationExpressions)
             {
-                var expressionAsString = expression.Body.ToString();
+                var expressionAsString = GetExpressionAsString(expression);
 
                 try
                 {
@@ -55,6 +55,81 @@
                     throw;
                 }
             }
+        }
+
+        /// <summary>
+        /// Converts an expression representing a service registration into a human-readable string.
+        /// The string includes the method name, generic arguments (if any), and the parameters passed to the method.
+        /// Extension methods are handled by recognizing the 'this' parameter (e.g., <see cref="IServiceCollection"/>).
+        /// This method is used to format log messages for service registration activities.
+        /// </summary>
+        /// <param name="expression">
+        /// The <see cref="Expression{Action}"/> object representing the service registration action to be converted to a string.
+        /// This expression is expected to be a method call expression.
+        /// </param>
+        /// <returns>
+        /// A formatted string representing the method call, including the method name, any generic arguments,
+        /// and the parameters passed to the method. If the method is an extension method, the 'this' parameter is explicitly marked.
+        /// </returns>
+        /// <exception cref="InvalidCastException">
+        /// Thrown if the expression body is not a <see cref="MethodCallExpression"/>. This method expects the expression body to be a method call.
+        /// </exception>
+        protected virtual string GetExpressionAsString(Expression<Action<IServiceCollection, IConfiguration>> expression)
+        {
+            var methodCall = (MethodCallExpression)expression.Body;
+
+            // Get the method name
+            string methodName = methodCall.Method.Name;
+
+            // Handle generic arguments (for cases like AddScoped<IMyService, MyService>)
+            string genericArgs = string.Empty;
+            if (methodCall.Method.IsGenericMethod)
+            {
+                var genericArguments = methodCall.Method.GetGenericArguments()
+                                                        .Select(arg => arg.Name)
+                                                        .ToArray();
+                genericArgs = $"<{string.Join(", ", genericArguments)}>";
+            }
+
+            // Handle normal parameters (for cases like AddScoped(typeof(IMyService), typeof(MyService)))
+            bool isExtensionMethod = methodCall.Method.IsDefined(typeof(System.Runtime.CompilerServices.ExtensionAttribute), false);
+            var normalArgs = methodCall.Arguments
+                                       .Select((arg, index) =>
+                                       {
+                                           if (index == 0 && isExtensionMethod)
+                                           {
+                                               return $"this {arg.Type.Name}";
+                                           }
+
+                                           if (arg is ConstantExpression constExpr && constExpr.Value != null)
+                                           {
+                                               return $"{constExpr.Type.Name}<{constExpr.Value}>";
+                                           }
+
+                                           if (arg is LambdaExpression lambdaExpr)
+                                           {
+                                               var parameters = lambdaExpr.Parameters.Select(x => x.Type.Name).ToArray();
+                                               var parameterString = string.Join(",", parameters);
+                                               return $"({parameterString}) => {lambdaExpr.Body}";
+                                           }
+
+                                           if (arg is MethodCallExpression methodCallExpr)
+                                           {
+                                               return methodCallExpr.Method.ReturnType.Name;
+                                           }
+
+                                           if (arg is TypeBinaryExpression typeBinaryExpr)
+                                           {
+                                               return typeBinaryExpr.Type.Name;
+                                           }
+
+                                           return arg.Type.Name;
+                                       })
+                                       .ToArray();
+
+            string parameters = string.Join(", ", normalArgs.Where(x => x != null));
+
+            return $"{methodName}{genericArgs}({parameters})";
         }
     }
 }

--- a/tst/StartupOrchestration.NET.UnitTests/ServiceRegistrationOrchestratorTests.cs
+++ b/tst/StartupOrchestration.NET.UnitTests/ServiceRegistrationOrchestratorTests.cs
@@ -60,8 +60,8 @@ public class ServiceRegistrationOrchestratorTests
         var orchestrator = new TestServiceRegistrationOrchestratorWithLogger();
         Expression<Action<IServiceCollection, IConfiguration>> expression = (x, y) => x.AddScoped<ITestCoreService, TestCoreService>();
         orchestrator.ServiceRegistrationExpressions.Add(expression);
-        var expectedStartedMessage = $"'{expression.Body}' was started...";
-        var expectedCompletedMessage = $"'{expression.Body}' completed successfully!";
+        var expectedStartedMessage = "'AddScoped<ITestCoreService, TestCoreService>(this IServiceCollection)' was started...";
+        var expectedCompletedMessage = "'AddScoped<ITestCoreService, TestCoreService>(this IServiceCollection)' completed successfully!";
 
         // Act
         using var scope = new StringWriter();
@@ -93,7 +93,7 @@ public class ServiceRegistrationOrchestratorTests
         var orchestrator = new TestServiceRegistrationOrchestratorWithLogger();
         Expression<Action<IServiceCollection, IConfiguration>> expression = (x, y) => x.ThrowInvalidOperationException();
         orchestrator.ServiceRegistrationExpressions.Add(expression);
-        var expectedFailureMessage = $"'{expression.Body}' failed with an unhandled exception.";
+        var expectedFailureMessage = "'ThrowInvalidOperationException(this IServiceCollection)' failed with an unhandled exception.";
 
         // Act
         using var scope = new StringWriter();
@@ -105,6 +105,136 @@ public class ServiceRegistrationOrchestratorTests
             LogLevel.Trace,
             It.IsAny<EventId>(),
             It.Is<It.IsAnyType>((o, t) => o.ToString()!.Contains(expectedFailureMessage)),
+            It.IsAny<Exception>(),
+            It.IsAny<Func<It.IsAnyType, Exception, string>>()!), Times.Once);
+    }
+
+    [Fact]
+    public void Orchestrate_LogsServiceRegistration_WithNoParameters()
+    {
+        // Arrange
+        var serviceCollection = new ServiceCollection();
+        var configuration = new ConfigurationBuilder().Build();
+        var orchestrator = new TestServiceRegistrationOrchestratorWithLogger();
+        Expression<Action<IServiceCollection, IConfiguration>> expression = (x, y) => x.AddService();
+        orchestrator.ServiceRegistrationExpressions.Add(expression);
+        var expectedStartedMessage = "'AddService(this IServiceCollection)' was started...";
+        var expectedCompletedMessage = "'AddService(this IServiceCollection)' completed successfully!";
+
+        // Act
+        orchestrator.Orchestrate(serviceCollection, configuration);
+
+        // Assert
+        orchestrator.GetLogger().Verify(logger => logger.Log(
+            LogLevel.Trace,
+            It.IsAny<EventId>(),
+            It.Is<It.IsAnyType>((o, t) => o.ToString()!.Contains(expectedStartedMessage)),
+            It.IsAny<Exception>(),
+            It.IsAny<Func<It.IsAnyType, Exception, string>>()!), Times.Once);
+
+        orchestrator.GetLogger().Verify(logger => logger.Log(
+            LogLevel.Trace,
+            It.IsAny<EventId>(),
+            It.Is<It.IsAnyType>((o, t) => o.ToString()!.Contains(expectedCompletedMessage)),
+            It.IsAny<Exception>(),
+            It.IsAny<Func<It.IsAnyType, Exception, string>>()!), Times.Once);
+    }
+
+    [Fact]
+    public void Orchestrate_LogsServiceRegistration_WithGenericParameters()
+    {
+        // Arrange
+        var serviceCollection = new ServiceCollection();
+        var configuration = new ConfigurationBuilder().Build();
+        var orchestrator = new TestServiceRegistrationOrchestratorWithLogger();
+        Expression<Action<IServiceCollection, IConfiguration>> expression = (x, y) => x.AddScoped<ITestCoreService, TestCoreService>();
+        orchestrator.ServiceRegistrationExpressions.Add(expression);
+        var expectedStartedMessage = "'AddScoped<ITestCoreService, TestCoreService>(this IServiceCollection)' was started...";
+        var expectedCompletedMessage = "'AddScoped<ITestCoreService, TestCoreService>(this IServiceCollection)' completed successfully!";
+
+        // Act
+        orchestrator.Orchestrate(serviceCollection, configuration);
+
+        // Assert
+        orchestrator.GetLogger().Verify(logger => logger.Log(
+            LogLevel.Trace,
+            It.IsAny<EventId>(),
+            It.Is<It.IsAnyType>((o, t) => o.ToString()!.Contains(expectedStartedMessage)),
+            It.IsAny<Exception>(),
+            It.IsAny<Func<It.IsAnyType, Exception, string>>()!), Times.Once);
+
+        orchestrator.GetLogger().Verify(logger => logger.Log(
+            LogLevel.Trace,
+            It.IsAny<EventId>(),
+            It.Is<It.IsAnyType>((o, t) => o.ToString()!.Contains(expectedCompletedMessage)),
+            It.IsAny<Exception>(),
+            It.IsAny<Func<It.IsAnyType, Exception, string>>()!), Times.Once);
+    }
+
+    [Fact]
+    public void Orchestrate_LogsServiceRegistration_WithNormalParameters()
+    {
+        // Arrange
+        var serviceCollection = new ServiceCollection();
+        var configuration = new ConfigurationBuilder().Build();
+        var orchestrator = new TestServiceRegistrationOrchestratorWithLogger();
+        Expression<Action<IServiceCollection, IConfiguration>> expression = (x, y) => x.AddScoped(typeof(ITestCoreService), typeof(TestCoreService));
+        orchestrator.ServiceRegistrationExpressions.Add(expression);
+        var expectedStartedMessage = "'AddScoped(this IServiceCollection, Type<StartupOrchestration.NET.UnitTests.TestClasses.ITestCoreService>, Type<StartupOrchestration.NET.UnitTests.TestClasses.TestCoreService>)' was started...";
+        var expectedCompletedMessage = "'AddScoped(this IServiceCollection, Type<StartupOrchestration.NET.UnitTests.TestClasses.ITestCoreService>, Type<StartupOrchestration.NET.UnitTests.TestClasses.TestCoreService>)' completed successfully!";
+
+        // Act
+        orchestrator.Orchestrate(serviceCollection, configuration);
+
+        // Assert
+        orchestrator.GetLogger().Verify(logger => logger.Log(
+            LogLevel.Trace,
+            It.IsAny<EventId>(),
+            It.Is<It.IsAnyType>((o, t) => o.ToString()!.Contains(expectedStartedMessage)),
+            It.IsAny<Exception>(),
+            It.IsAny<Func<It.IsAnyType, Exception, string>>()!), Times.Once);
+
+        orchestrator.GetLogger().Verify(logger => logger.Log(
+            LogLevel.Trace,
+            It.IsAny<EventId>(),
+            It.Is<It.IsAnyType>((o, t) => o.ToString()!.Contains(expectedCompletedMessage)),
+            It.IsAny<Exception>(),
+            It.IsAny<Func<It.IsAnyType, Exception, string>>()!), Times.Once);
+    }
+
+    [Fact]
+    public void Orchestrate_LogsServiceRegistration_WithLambdaExpression()
+    {
+        // Arrange
+        var serviceCollection = new ServiceCollection();
+        var configuration = new ConfigurationBuilder().Build();
+        var orchestrator = new TestServiceRegistrationOrchestratorWithLogger();
+
+        // Lambda expression: AddScoped<ITestCoreService>(services => new TestCoreService())
+        Expression<Action<IServiceCollection, IConfiguration>> expression = (x, y) => x.AddScoped<ITestCoreService>(services => new TestCoreService());
+        orchestrator.ServiceRegistrationExpressions.Add(expression);
+
+        // Expected messages for logging
+        var expectedStartedMessage = "'AddScoped<ITestCoreService>(this IServiceCollection, (IServiceProvider) => new TestCoreService())' was started...";
+        var expectedCompletedMessage = "'AddScoped<ITestCoreService>(this IServiceCollection, (IServiceProvider) => new TestCoreService())' completed successfully!";
+
+        // Act
+        orchestrator.Orchestrate(serviceCollection, configuration);
+
+        // Assert
+        // Verify that the logger logged the "started" message with the lambda expression details
+        orchestrator.GetLogger().Verify(logger => logger.Log(
+            LogLevel.Trace,
+            It.IsAny<EventId>(),
+            It.Is<It.IsAnyType>((o, t) => o.ToString()!.Contains(expectedStartedMessage)),
+            It.IsAny<Exception>(),
+            It.IsAny<Func<It.IsAnyType, Exception, string>>()!), Times.Once);
+
+        // Verify that the logger logged the "completed" message with the lambda expression details
+        orchestrator.GetLogger().Verify(logger => logger.Log(
+            LogLevel.Trace,
+            It.IsAny<EventId>(),
+            It.Is<It.IsAnyType>((o, t) => o.ToString()!.Contains(expectedCompletedMessage)),
             It.IsAny<Exception>(),
             It.IsAny<Func<It.IsAnyType, Exception, string>>()!), Times.Once);
     }

--- a/tst/StartupOrchestration.NET.UnitTests/TestClasses/TestExtensions.cs
+++ b/tst/StartupOrchestration.NET.UnitTests/TestClasses/TestExtensions.cs
@@ -18,5 +18,10 @@ namespace StartupOrchestration.NET.UnitTests.TestClasses
         {
             throw new InvalidOperationException();
         }
+
+        internal static IServiceCollection AddService(this IServiceCollection services)
+        {
+            return services;
+        }
     }
 }


### PR DESCRIPTION
- Added logic to `Orchestrate` method to distinguish between extension methods and standard method calls.
- Implemented `GetExpressionAsString` to format service registration expressions into readable strings for logging.
  - Handles generic parameters, normal parameters, and lambda expressions.
  - Explicitly calls out 'this' parameter for extension methods (e.g., `IServiceCollection`).
  - Formats lambda expressions and constant values properly in log messages.