### PR TITLE
feat(Service Registration): Rename pipeline logger and expand docs and test coverage #breaking

### DIFF
--- a/src/ServiceComposition.NET/ExpressionExtensions.cs
+++ b/src/ServiceComposition.NET/ExpressionExtensions.cs
@@ -1,70 +1,137 @@
 ﻿namespace ServiceComposition.NET;
 
 /// <summary>
-/// Provides extension methods for working with <see cref="Expression"/> objects.
+/// Provides extension methods for validating service registration expressions
+/// used within service composition pipelines.
 /// </summary>
+/// <remarks>
+/// These validation methods enforce the structural constraints required by
+/// <see cref="ServiceRegistrationPipeline"/> and
+/// <see cref="ServiceRegistrationExpressionCollection"/>.
+/// <para>
+/// A valid service registration expression must:
+/// <list type="bullet">
+/// <item>
+/// Represent a single method call expression.
+/// </item>
+/// <item>
+/// Invoke an extension method.
+/// </item>
+/// <item>
+/// Target <see cref="IServiceCollection"/> as the extension method's first parameter.
+/// </item>
+/// </list>
+/// </para>
+/// Validation occurs at the time an expression is added to a pipeline,
+/// ensuring invalid registrations are rejected before execution.
+/// </remarks>
 public static class ExpressionExtensions
 {
     /// <summary>
     /// Validates a service registration expression that requires access to configuration.
     /// </summary>
     /// <param name="registrationExpression">
-    /// The service registration expression to validate.
+    /// A lambda expression representing a service registration operation.
     /// </param>
-    /// <exception cref="ArgumentException">
-    /// Thrown when the expression does not represent a valid service registration call.
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="registrationExpression"/> is <see langword="null"/>.
     /// </exception>
-    public static void ValidateServiceRegistration(this Expression<Action<IServiceCollection, IConfiguration>> registrationExpression)
-    {
-        if (registrationExpression?.Body is not MethodCallExpression methodCallExpression)
-        {
-            throw new ArgumentException(
-                "Registration expression must be a call to a method on IServiceCollection.",
-                nameof(registrationExpression));
-        }
+    /// <exception cref="ArgumentException">
+    /// Thrown when the expression is not a valid service registration call.
+    /// </exception>
+    /// <remarks>
+    /// The expression must represent a single extension method call on
+    /// <see cref="IServiceCollection"/>. For example:
+    /// <para>
+    /// <c>(services, configuration) =&gt; services.AddScoped&lt;IMyService, MyService&gt;()</c>
+    /// </para>
+    /// </remarks>
+    public static void ValidateServiceRegistration(this Expression<Action<IServiceCollection, IConfiguration>>? registrationExpression) =>
+        ValidateCore(registrationExpression);
 
-        if (!methodCallExpression.IsValidServiceCollectionExtension())
-        {
+    /// <summary>
+    /// Validates a service registration expression that does not require configuration.
+    /// </summary>
+    /// <param name="registrationExpression">
+    /// A lambda expression representing a service registration operation.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="registrationExpression"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown when the expression is not a valid service registration call.
+    /// </exception>
+    /// <remarks>
+    /// The expression must represent a single extension method call on
+    /// <see cref="IServiceCollection"/>. For example:
+    /// <para>
+    /// <c>services =&gt; services.AddSingleton&lt;IMyService, MyService&gt;()</c>
+    /// </para>
+    /// </remarks>
+    public static void ValidateServiceRegistration(this Expression<Action<IServiceCollection>>? registrationExpression) =>
+        ValidateCore(registrationExpression);
+
+    /// <summary>
+    /// Performs core validation logic for service registration expressions.
+    /// </summary>
+    /// <param name="registrationExpression">
+    /// The lambda expression to validate.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="registrationExpression"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown when the expression is not a single method call targeting a valid
+    /// <see cref="IServiceCollection"/> extension method.
+    /// </exception>
+    private static void ValidateCore(LambdaExpression? registrationExpression)
+    {
+        if (registrationExpression is null)
+            throw new ArgumentNullException(nameof(registrationExpression));
+
+        if (registrationExpression.Body is not MethodCallExpression methodCallExpression)
             throw new ArgumentException(
-                "Only extension methods declared on IServiceCollection are allowed as service registration expressions.",
+                "Registration expression must be a single method call on IServiceCollection.",
                 nameof(registrationExpression));
-        }
+
+        methodCallExpression.EnsureValidServiceCollectionExtension();
     }
 
     /// <summary>
-    /// Validates a service registration expression that does not require access to configuration.
+    /// Ensures the method call represents a valid <see cref="IServiceCollection"/> extension.
     /// </summary>
-    /// <param name="registrationExpression">
-    /// The service registration expression to validate.
+    /// <param name="methodCallExpression">
+    /// The method call expression to validate.
     /// </param>
     /// <exception cref="ArgumentException">
-    /// Thrown when the expression does not represent a valid service registration call.
+    /// Thrown when the method is not an extension method declared for
+    /// <see cref="IServiceCollection"/>.
     /// </exception>
-    public static void ValidateServiceRegistration(this Expression<Action<IServiceCollection>> registrationExpression)
+    private static void EnsureValidServiceCollectionExtension(
+        this MethodCallExpression methodCallExpression)
     {
-        if (registrationExpression?.Body is not MethodCallExpression methodCallExpression)
-        {
-            throw new ArgumentException(
-                "Registration expression must be a call to a method on IServiceCollection.",
-                nameof(registrationExpression));
-        }
+        var method = methodCallExpression.Method;
 
-        if (!methodCallExpression.IsValidServiceCollectionExtension())
-        {
-            throw new ArgumentException(
-                "Only extension methods declared on IServiceCollection are allowed as service registration expressions.",
-                nameof(registrationExpression));
-        }
+        var isAssignableFromIServiceCollection =
+            method.GetParameters().Length > 0 &&
+            typeof(IServiceCollection).IsAssignableFrom(method.GetParameters()[0].ParameterType);
+
+        var isValid = method.IsExtensionMethod() && isAssignableFromIServiceCollection;
+
+        if (!isValid)
+            throw new ArgumentException("Only extension methods declared on IServiceCollection are allowed as service registration expressions.");
     }
 
-    private static bool IsValidServiceCollectionExtension(this MethodCallExpression methodCallExpression)
-    {
-        return methodCallExpression.Method.IsExtensionMethod() &&
-               typeof(IServiceCollection).IsAssignableFrom(methodCallExpression.Method.GetParameters()[0].ParameterType);
-    }
-
-    private static bool IsExtensionMethod(this MethodInfo methodInfo)
-    {
-        return methodInfo.IsDefined(typeof(System.Runtime.CompilerServices.ExtensionAttribute), false);
-    }
+    /// <summary>
+    /// Determines whether a method is defined as an extension method.
+    /// </summary>
+    /// <param name="methodInfo">
+    /// The method to inspect.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> if the method is marked with <see cref="System.Runtime.CompilerServices.ExtensionAttribute"/>;
+    /// otherwise, <see langword="false"/>.
+    /// </returns>
+    internal static bool IsExtensionMethod(this MethodInfo methodInfo) =>
+        methodInfo.IsDefined(typeof(System.Runtime.CompilerServices.ExtensionAttribute), false);
 }

--- a/tst/ServiceComposition.NET.IntegrationTests/ServiceComposition.NET.IntegrationTests.csproj
+++ b/tst/ServiceComposition.NET.IntegrationTests/ServiceComposition.NET.IntegrationTests.csproj
@@ -16,6 +16,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/tst/ServiceComposition.NET.IntegrationTests/TestClasses/TestServiceRegistrationPipeline.cs
+++ b/tst/ServiceComposition.NET.IntegrationTests/TestClasses/TestServiceRegistrationPipeline.cs
@@ -7,7 +7,7 @@ namespace ServiceComposition.NET.IntegrationTests.TestClasses;
 internal class TestServiceRegistrationPipeline : ServiceRegistrationPipeline
 {
     /// <inheritdoc />
-    protected override ILogger StartupLogger => NullLogger.Instance;
+    protected override ILogger Logger => NullLogger.Instance;
 
     public TestServiceRegistrationPipeline()
     {

--- a/tst/ServiceComposition.NET.UnitTests/ServiceComposition.NET.UnitTests.csproj
+++ b/tst/ServiceComposition.NET.UnitTests/ServiceComposition.NET.UnitTests.csproj
@@ -12,6 +12,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/tst/ServiceComposition.NET.UnitTests/ServiceRegistrationExpressionCollectionTests.cs
+++ b/tst/ServiceComposition.NET.UnitTests/ServiceRegistrationExpressionCollectionTests.cs
@@ -1,0 +1,196 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ServiceComposition.NET.UnitTests;
+
+public class ServiceRegistrationExpressionCollectionTests
+{
+    private sealed class TestCollection : ServiceRegistrationExpressionCollection
+    {
+        public IReadOnlyList<Expression<Action<IServiceCollection, IConfiguration>>> GetExpressions() => Expressions;
+    }
+
+    private interface ITestService;
+    private class TestService : ITestService;
+
+    #region AddRegistration (Configuration Aware)
+
+    [Fact]
+    public void AddRegistration_WithConfiguration_AddsExpression()
+    {
+        var collection = new TestCollection();
+
+        Expression<Action<IServiceCollection, IConfiguration>> expr =
+            (services, config) => services.AddScoped<ITestService, TestService>();
+
+        collection.AddRegistration(expr);
+
+        Assert.Single(collection.GetExpressions());
+    }
+
+    [Fact]
+    public void AddRegistration_WithConfiguration_Null_Throws()
+    {
+        var collection = new TestCollection();
+
+        Assert.Throws<ArgumentNullException>(() =>
+            collection.AddRegistration((Expression<Action<IServiceCollection, IConfiguration>>)null!));
+    }
+
+    #endregion
+
+    #region AddRegistration (Without Configuration)
+
+    [Fact]
+    public void AddRegistration_WithoutConfiguration_AddsLiftedExpression()
+    {
+        var collection = new TestCollection();
+
+        Expression<Action<IServiceCollection>> expr =
+            services => services.AddSingleton<ITestService, TestService>();
+
+        collection.AddRegistration(expr);
+
+        var stored = collection.GetExpressions().Single();
+
+        Assert.NotNull(stored);
+        Assert.Equal(2, stored.Parameters.Count);
+        Assert.Equal(typeof(IServiceCollection), stored.Parameters[0].Type);
+        Assert.Equal(typeof(IConfiguration), stored.Parameters[1].Type);
+    }
+
+    [Fact]
+    public void AddRegistration_WithoutConfiguration_Null_Throws()
+    {
+        var collection = new TestCollection();
+
+        Assert.Throws<ArgumentNullException>(() =>
+            collection.AddRegistration((Expression<Action<IServiceCollection>>)null!));
+    }
+
+    #endregion
+
+    #region AddRegistrations (Configuration Aware)
+
+    [Fact]
+    public void AddRegistrations_WithConfiguration_AddsAllInOrder()
+    {
+        var collection = new TestCollection();
+
+        var expr1 = (Expression<Action<IServiceCollection, IConfiguration>>)
+            ((s, c) => s.AddScoped<ITestService, TestService>());
+
+        var expr2 = (Expression<Action<IServiceCollection, IConfiguration>>)
+            ((s, c) => s.AddSingleton<ITestService, TestService>());
+
+        collection.AddRegistrations([expr1, expr2]);
+
+        var stored = collection.GetExpressions();
+
+        Assert.Equal(2, stored.Count);
+        Assert.Same(expr1, stored[0]);
+        Assert.Same(expr2, stored[1]);
+    }
+
+    [Fact]
+    public void AddRegistrations_WithConfiguration_NullCollection_Throws()
+    {
+        var collection = new TestCollection();
+
+        Assert.Throws<ArgumentNullException>(() =>
+            collection.AddRegistrations((IEnumerable<Expression<Action<IServiceCollection, IConfiguration>>>)null!));
+    }
+
+    #endregion
+
+    #region AddRegistrations (Without Configuration)
+
+    [Fact]
+    public void AddRegistrations_WithoutConfiguration_AddsAllLifted()
+    {
+        var collection = new TestCollection();
+
+        var expr1 = (Expression<Action<IServiceCollection>>)
+            (s => s.AddScoped<ITestService, TestService>());
+
+        var expr2 = (Expression<Action<IServiceCollection>>)
+            (s => s.AddSingleton<ITestService, TestService>());
+
+        collection.AddRegistrations([expr1, expr2]);
+
+        var stored = collection.GetExpressions();
+
+        Assert.Equal(2, stored.Count);
+        Assert.All(stored, e => Assert.Equal(2, e.Parameters.Count));
+    }
+
+    [Fact]
+    public void AddRegistrations_WithoutConfiguration_NullCollection_Throws()
+    {
+        var collection = new TestCollection();
+
+        Assert.Throws<ArgumentNullException>(() =>
+            collection.AddRegistrations((IEnumerable<Expression<Action<IServiceCollection>>>)null!));
+    }
+
+    #endregion
+
+    #region Validation Behavior
+
+    [Fact]
+    public void AddRegistration_InvalidTargetMethod_Throws()
+    {
+        var collection = new TestCollection();
+
+        Expression<Action<IServiceCollection>> invalid =
+            services => services.ToString(); // Not IServiceCollection extension
+
+        Assert.Throws<ArgumentException>(() =>
+            collection.AddRegistration(invalid));
+    }
+
+    [Fact]
+    public void AddRegistrations_StopsOnFirstInvalidExpression()
+    {
+        var collection = new TestCollection();
+
+        var valid = (Expression<Action<IServiceCollection>>)
+            (s => s.AddScoped<ITestService, TestService>());
+
+        var invalid = (Expression<Action<IServiceCollection>>)
+            (s => s.ToString());
+
+        Assert.Throws<ArgumentException>(() =>
+            collection.AddRegistrations([valid, invalid]));
+
+        // Only the first valid one should have been added
+        Assert.Single(collection.GetExpressions());
+    }
+
+    #endregion
+
+    #region Ordering Guarantee
+
+    [Fact]
+    public void Expressions_PreserveInsertionOrder()
+    {
+        var collection = new TestCollection();
+
+        var expr1 = (Expression<Action<IServiceCollection>>)
+            (s => s.AddScoped<ITestService, TestService>());
+
+        var expr2 = (Expression<Action<IServiceCollection>>)
+            (s => s.AddSingleton<ITestService, TestService>());
+
+        collection.AddRegistration(expr1);
+        collection.AddRegistration(expr2);
+
+        var stored = collection.GetExpressions();
+
+        Assert.Equal(2, stored.Count);
+        Assert.Equal("AddScoped", ((MethodCallExpression)stored[0].Body).Method.Name);
+        Assert.Equal("AddSingleton", ((MethodCallExpression)stored[1].Body).Method.Name);
+    }
+
+    #endregion
+}

--- a/tst/ServiceComposition.NET.UnitTests/TestClasses/TestServiceRegistrationPipeline.cs
+++ b/tst/ServiceComposition.NET.UnitTests/TestClasses/TestServiceRegistrationPipeline.cs
@@ -8,7 +8,7 @@ namespace ServiceComposition.NET.UnitTests.TestClasses;
 
 internal sealed class TestServiceRegistrationPipeline : ServiceRegistrationPipeline
 {
-    protected override ILogger StartupLogger => NullLogger.Instance;
+    protected override ILogger Logger => NullLogger.Instance;
 
     public TestServiceRegistrationPipeline()
     {

--- a/tst/ServiceComposition.NET.UnitTests/TestClasses/TestServiceRegistrationPipelineWithLogger.cs
+++ b/tst/ServiceComposition.NET.UnitTests/TestClasses/TestServiceRegistrationPipelineWithLogger.cs
@@ -6,7 +6,7 @@ internal sealed class TestServiceRegistrationPipelineWithLogger : ServiceRegistr
 {
     private readonly Mock<ILogger> _mockLogger = new();
 
-    protected override ILogger StartupLogger => _mockLogger.Object;
+    protected override ILogger Logger => _mockLogger.Object;
 
     internal Mock<ILogger> GetLogger()
     {


### PR DESCRIPTION
Refined the service registration pipeline for clarity, consistency, and reliability.

Pipeline:
- Renamed `StartupLogger` to `Logger` in **ServiceRegistrationPipeline** for clearer abstraction and naming consistency while preserving startup-safe logging semantics (no DI dependency required)

Validation:
- Refactored expression validation logic to reduce duplication and improve internal reuse (no behavioral changes)

Documentation:
- Expanded and clarified XML documentation for expression validation invariants, canonical expression normalization, and execution semantics including ordering guarantees
- Added README guidance for configuring the pipeline logger, environment-aware logging, and controlled opt-out scenarios

Testing:
- Increased unit test coverage for invocation expressions, instance methods, invalid extension targets, expression lifting behavior, and expression string formatting (including method call and type binary arguments)
- Strengthened log message assertions to verify formatted output explicitly

BREAKING CHANGE:
- `StartupLogger` property renamed to `Logger` in **ServiceRegistrationPipeline**